### PR TITLE
Fixed description of Langevin thermostat

### DIFF
--- a/paper/basic_training.tex
+++ b/paper/basic_training.tex
@@ -784,7 +784,7 @@ This is not an exhaustive study of available thermostats, but is instead a surve
 
         The Langevin\cite{schneider1978molecular} thermostat supplements the microcanonical equations of motion with Brownian dynamics, thus including the viscosity and random collision effects of an implicit solvent.
         It uses a general equation of the form $F = F_{interaction} + F_{friction} + F_{random}$, where $F_{interaction}$ is the standard interactions calculated during the simulation, $F_{friction}$ is the damping used to tune the ``viscosity'' of the implicit bath, and $F_{random}$ effectively gives random collisions with solvent molecules.
-        Careful consideration must be taken when choosing the friction damping parameter; in the limit of a zero damping parameter, the dynamics are microcanonical\footnote{With no damping this does not reduce to the Andersen thermostat, since no damping also means no random force because the magnitude of the damping is coupled to the magnitude of the random force by the fluctuation/dissipation theorem.}, and in the limit of an infinite damping parameter, the dynamics are purely Brownian.
+        The frictional and random forces are coupled through a user-specified friction damping parameter. Careful consideration must be taken when choosing this parameter; in the limit of a zero damping parameter, both frictional and random forces go to zero and the dynamics become microcanonical, and in the limit of an infinite damping parameter, the dynamics are purely Brownian.
 
     \item {\bf{Nos\'{e}-Hoover}}
 


### PR DESCRIPTION
This would bring in Efrem's proposed edits from [here](
https://github.com/MobleyLab/basic_simulation_training/issues/89#issuecomment-436607909); basically we apparently confused the reviewer about damping vs friction with Langevin. We'd added a footnote to try and clarify, but this is probably a better solution.